### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Terraform Registry MCP Server
+[![smithery badge](https://smithery.ai/badge/@thrashr888/terraform-mcp-server)](https://smithery.ai/server/@thrashr888/terraform-mcp-server)
 
 A Model Context Protocol (MCP) server that provides tools for interacting with the Terraform Registry API. This server enables AI agents to query provider information, resource details, module metadata, and generate example configurations.
 
@@ -247,6 +248,15 @@ Generates a minimal Terraform configuration for a given provider and resource.
 
 ## Running the Server
 
+### Installing via Smithery
+
+To install Terraform Registry MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@thrashr888/terraform-mcp-server):
+
+```bash
+npx -y @smithery/cli install @thrashr888/terraform-mcp-server --client claude
+```
+
+### Manual Installation
 The server runs using stdio transport for MCP communication:
 
 ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,13 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    properties: {}
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['/app/dist/index.js'], env: {} })
+  exampleConfig: {}


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@thrashr888/terraform-mcp-server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂