### PR TITLE
build: update to build image for multiple target architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -45,10 +47,11 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/terraform-mcp-server:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/terraform-mcp-server:${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
Suggested change to build for multiple target architectures. Including arm64, which will allow to run on Apple Silicon.
(And bump version of action)